### PR TITLE
Revert Max player storage rework

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/CivModCorePlugin.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/CivModCorePlugin.java
@@ -19,6 +19,7 @@ import vg.civcraft.mc.civmodcore.maps.MapColours;
 import vg.civcraft.mc.civmodcore.players.scoreboard.bottom.BottomLineAPI;
 import vg.civcraft.mc.civmodcore.players.scoreboard.side.ScoreBoardAPI;
 import vg.civcraft.mc.civmodcore.players.scoreboard.side.ScoreBoardListener;
+import vg.civcraft.mc.civmodcore.players.settings.PlayerSettingAPI;
 import vg.civcraft.mc.civmodcore.players.settings.commands.ConfigCommand;
 import vg.civcraft.mc.civmodcore.utilities.SkinCache;
 import vg.civcraft.mc.civmodcore.world.WorldTracker;
@@ -109,6 +110,7 @@ public final class CivModCorePlugin extends ACivMod {
 		}
 		DialogManager.resetDialogs();
 		WorldTracker.reset();
+		PlayerSettingAPI.saveAll();
 		ConfigurationSerialization.unregisterClass(DatabaseCredentials.class);
 		if (this.commands != null) {
 			this.commands.reset();

--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/players/settings/PlayerSetting.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/players/settings/PlayerSetting.java
@@ -3,10 +3,11 @@ package vg.civcraft.mc.civmodcore.players.settings;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang.WordUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -35,7 +36,7 @@ public abstract class PlayerSetting<T> {
 			String description, boolean canBeChangedByPlayer) {
 		Preconditions.checkNotNull(gui, "GUI ItemStack can not be null.");
 
-		this.values = new ConcurrentHashMap<>();
+		this.values = new TreeMap<>();
 		this.defaultValue = defaultValue;
 		this.owningPlugin = owningPlugin;
 		this.niceName = niceName;
@@ -61,6 +62,13 @@ public abstract class PlayerSetting<T> {
 	 */
 	public abstract T deserialize(String serial);
 
+	Map<String, String> dumpAllSerialized() {
+		Map<String, String> result = new HashMap<>();
+		for (Map.Entry<UUID, T> entry : values.entrySet()) {
+			result.put(entry.getKey().toString(), serialize(entry.getValue()));
+		}
+		return result;
+	}
 
 	/**
 	 * @return Textual description shown in the GUI for this setting

--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/players/settings/PlayerSettingAPI.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/players/settings/PlayerSettingAPI.java
@@ -1,13 +1,18 @@
 package vg.civcraft.mc.civmodcore.players.settings;
 
 import com.google.common.base.Preconditions;
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import lombok.experimental.UtilityClass;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import vg.civcraft.mc.civmodcore.CivModCorePlugin;
 import vg.civcraft.mc.civmodcore.players.settings.gui.MenuOption;
 import vg.civcraft.mc.civmodcore.players.settings.gui.MenuSection;
 import vg.civcraft.mc.civmodcore.players.settings.impl.AltConsistentSetting;
@@ -20,9 +25,11 @@ import vg.civcraft.mc.civmodcore.players.settings.impl.AltConsistentSetting;
 @UtilityClass
 public final class PlayerSettingAPI {
 
-	private static final Map<String, PlayerSetting<?>> SETTINGS_BY_IDENTIFIER = new ConcurrentHashMap<>();
+	private static final String FILE_NAME = "civ-player-settings.yml";
 
-	private static final Map<String, List<PlayerSetting<?>>> SETTINGS_BY_PLUGIN = new ConcurrentHashMap<>();
+	private static final Map<String, PlayerSetting<?>> SETTINGS_BY_IDENTIFIER = new HashMap<>();
+
+	private static final Map<String, List<PlayerSetting<?>>> SETTINGS_BY_PLUGIN = new HashMap<>();
 
 	private static final MenuSection MAIN_MENU = new MenuSection("Config", "", null);
 
@@ -47,6 +54,25 @@ public final class PlayerSettingAPI {
 		return SETTINGS_BY_IDENTIFIER.get(identifier);
 	}
 
+	private static void loadValues(PlayerSetting<?> setting) {
+		File folder = setting.getOwningPlugin().getDataFolder();
+		if (!folder.isDirectory()) {
+			return;
+		}
+		File file = new File(folder, FILE_NAME);
+		if (!file.isFile()) {
+			return;
+		}
+		YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+		ConfigurationSection section = config.getConfigurationSection(setting.getIdentifier());
+		if (section == null) {
+			return;
+		}
+		for (String key : section.getKeys(false)) {
+			setting.load(key, section.getString(key));
+		}
+	}
+
 	/**
 	 * Settings must be registered on every startup to be available. Identifiers
 	 * must be unique globally.
@@ -66,6 +92,7 @@ public final class PlayerSettingAPI {
 			menu = null;
 			setting = ((AltConsistentSetting<?,?>) setting).getWrappedSetting();
 		}
+		loadValues(setting);
 		List<PlayerSetting<?>> pluginSettings = SETTINGS_BY_PLUGIN.computeIfAbsent(
 				setting.getOwningPlugin().getName(),
 				k -> new ArrayList<>());
@@ -75,6 +102,54 @@ public final class PlayerSettingAPI {
 		pluginSettings.add(setting);
 		if (menu != null && setting.canBeChangedByPlayer()) {
 			menu.addItem(new MenuOption(menu, setting));
+		}
+	}
+
+	// TODO: While this deregisteres the settings, those settings then need to be removed from menus
+	//    Maybe menus need a rework?
+//	public static void deregisterPluginSettings(Plugin plugin) {
+//		Preconditions.checkArgument(plugin != null);
+//		Iteration.iterateThenClear(SETTINGS_BY_PLUGIN.get(plugin.getName()), (setting) ->
+//				SETTINGS_BY_IDENTIFIER.remove(setting.getIdentifier()));
+//		SETTINGS_BY_PLUGIN.remove(plugin.getName());
+//	}
+
+	/**
+	 * Saves all values to their save files
+	 */
+	public static void saveAll() {
+		for (Map.Entry<String, List<PlayerSetting<?>>> pluginEntry : SETTINGS_BY_PLUGIN.entrySet()) {
+			if (pluginEntry.getValue().isEmpty()) {
+				continue;
+			}
+			File folder = pluginEntry.getValue().get(0).getOwningPlugin().getDataFolder();
+			if (!folder.isDirectory()) {
+				folder.mkdirs();
+			}
+			File file = new File(folder, FILE_NAME);
+			YamlConfiguration config;
+			if (file.isFile()) {
+				config = YamlConfiguration.loadConfiguration(file);
+			}
+			else {
+				config = new YamlConfiguration();
+			}
+			for (PlayerSetting<?> setting : pluginEntry.getValue()) {
+				ConfigurationSection section;
+				if (config.isConfigurationSection(setting.getIdentifier())) {
+					section = config.getConfigurationSection(setting.getIdentifier());
+				} else {
+					section = config.createSection(setting.getIdentifier());
+				}
+				for (Map.Entry<String, String> entry : setting.dumpAllSerialized().entrySet()) {
+					section.set(entry.getKey(), entry.getValue());
+				}
+			}
+			try {
+				config.save(file);
+			} catch (IOException e) {
+				CivModCorePlugin.getInstance().severe("Failed to save settings", e);
+			}
 		}
 	}
 }

--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/players/settings/commands/ConfigCommand.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/players/settings/commands/ConfigCommand.java
@@ -27,6 +27,14 @@ public final class ConfigCommand extends BaseCommand {
 		PlayerSettingAPI.getMainMenu().showScreen(sender);
 	}
 
+	@Subcommand("save")
+	@Description("Save all settings to the file.")
+	@CommandPermission("cmc.config.save")
+	public void save(CommandSender sender) {
+		PlayerSettingAPI.saveAll();
+		sender.sendMessage(ChatColor.GREEN + "/config has been saved.");
+	}
+
 	@Subcommand("get")
 	@Description("Lets you read any config setting for any player")
 	@Syntax("config get <player|uuid> <setting>")


### PR DESCRIPTION
We need to hook into players nbt being saved in order to properly take advantage of this. That functionality is purely on sharding, we don't touch that stuff otherwise