### PR TITLE
Make method ChunkMetaAPI.removePlugin public

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/api/ChunkMetaAPI.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/api/ChunkMetaAPI.java
@@ -98,7 +98,7 @@ public class ChunkMetaAPI {
 		return view;
 	}
 
-	static void removePlugin(JavaPlugin plugin) {
+	public static void removePlugin(JavaPlugin plugin) {
 		existingViews.remove(plugin.getName());
 	}
 


### PR DESCRIPTION
Let me call this method without reflection.

It could be useful, for example, when I want to reload config for the plugin and therefore need to re-attach the plugin in views list.