### PR TITLE
Introduce a new API method getChunkMetaIfLoaded

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Gradle properties
 group = net.civmc.civmodcore
-version = 2.2.0
+version = 2.2.1
 description = CivModCore
 
 # Custom Properties

--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/ChunkCoord.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/ChunkCoord.java
@@ -118,6 +118,14 @@ public class ChunkCoord extends XZWCoord {
 		return lastUnloadingTime;
 	}
 
+	ChunkMetaLoadStatus getMetaIfLoaded(short pluginID, boolean alwaysLoaded) {
+		if (!alwaysLoaded && !isFullyLoaded)
+			return new ChunkMetaLoadStatus(null, false);
+
+		ChunkMeta<?> meta = getMeta(pluginID, alwaysLoaded);
+
+		return new ChunkMetaLoadStatus(meta, true);
+	}
 	ChunkMeta<?> getMeta(short pluginID, boolean alwaysLoaded) {
 		if (!alwaysLoaded && !isFullyLoaded) {
 			// check before taking monitor. This is fine, because the loaded flag will never

--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/ChunkMetaLoadStatus.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/ChunkMetaLoadStatus.java
@@ -1,0 +1,11 @@
+package vg.civcraft.mc.civmodcore.world.locations.chunkmeta;
+
+public class ChunkMetaLoadStatus {
+	public final ChunkMeta<?> meta;
+	public final boolean isLoaded;
+
+	public ChunkMetaLoadStatus(ChunkMeta<?> meta, boolean isLoaded) {
+		this.meta = meta;
+		this.isLoaded = isLoaded;
+	}
+}

--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/GlobalChunkMetaManager.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/GlobalChunkMetaManager.java
@@ -66,6 +66,21 @@ public class GlobalChunkMetaManager {
 
 	/**
 	 * Retrieves ChunkMeta for the given plugin from the given chunk in the given
+	 * world.
+	 * If it is not loaded then just return and do not wait
+	 *
+	 * @param pluginID Internal id of the plugin the meta belongs to
+	 * @param world    World the chunk is in
+	 * @param chunkX   X-coord of the chunk
+	 * @param chunkZ   Z-coord of the chunk
+	 * @return Retrieved ChunkMetaLoadStatus for the given parameter
+	 */
+	public ChunkMetaLoadStatus getChunkMetaIfLoaded(short pluginID, World world, int chunkX, int chunkZ, boolean alwaysLoaded) {
+		return getWorldManager(world).getChunkMetaIfLoaded(pluginID, chunkX, chunkZ, alwaysLoaded);
+	}
+
+	/**
+	 * Retrieves ChunkMeta for the given plugin from the given chunk in the given
 	 * world. May be null if no such meta is specified yet
 	 * 
 	 * @param pluginID Internal id of the plugin the meta belongs to

--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/WorldChunkMetaManager.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/WorldChunkMetaManager.java
@@ -122,6 +122,25 @@ public class WorldChunkMetaManager {
 
 	/**
 	 * Retrieves the chunk meta for a specific chunk for a specific plugin.
+	 * If it is not loaded then just return and do not wait
+	 *
+	 * DO NOT USE THIS FOR UNLOADED CHUNKS, THINGS WILL BREAK HORRIBLY
+	 *
+	 * @param pluginID Internal id of the plugin
+	 * @param x        X-coordinate of the chunk
+	 * @param z        Z-coordinate of the chunk
+	 * @return ChunkMetaLoadStatus for the given parameter
+	 */
+	ChunkMetaLoadStatus getChunkMetaIfLoaded(short pluginID, int x, int z, boolean alwaysLoaded) {
+		ChunkCoord coord = getChunkCoord(x, z, false, false);
+		if (coord == null) {
+			return null;
+		}
+		return coord.getMetaIfLoaded(pluginID, alwaysLoaded);
+	}
+
+	/**
+	 * Retrieves the chunk meta for a specific chunk for a specific plugin.
 	 * 
 	 * DO NOT USE THIS FOR UNLOADED CHUNKS, THINGS WILL BREAK HORRIBLY
 	 * 

--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/api/ChunkMetaView.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/api/ChunkMetaView.java
@@ -6,6 +6,7 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.plugin.java.JavaPlugin;
 import vg.civcraft.mc.civmodcore.world.locations.chunkmeta.ChunkMeta;
+import vg.civcraft.mc.civmodcore.world.locations.chunkmeta.ChunkMetaLoadStatus;
 import vg.civcraft.mc.civmodcore.world.locations.chunkmeta.GlobalChunkMetaManager;
 import vg.civcraft.mc.civmodcore.world.locations.chunkmeta.block.BlockBasedChunkMeta;
 
@@ -90,6 +91,21 @@ public class ChunkMetaView<T extends ChunkMeta<?>> extends APIView {
 	/**
 	 * Retrieves chunk metadata for the given chunk with the given for this specific
 	 * plugin
+	 * If it is not loaded then just return and do not wait
+	 *
+	 * @param location Location of the chunk to get metadata for
+	 * @return ChunkMetaLoadStatus for the requested chunk owned by this plugin
+	 */
+	public ChunkMetaLoadStatus getChunkMetaIfLoaded(Location location) {
+		if (location == null) {
+			throw new IllegalArgumentException("Location may not be null");
+		}
+		return getChunkMetaIfLoaded(location.getWorld(), BlockBasedChunkMeta.toChunkCoord(location.getBlockX()), BlockBasedChunkMeta.toChunkCoord(location.getBlockZ()));
+	}
+
+	/**
+	 * Retrieves chunk metadata for the given chunk with the given for this specific
+	 * plugin
 	 * 
 	 * @param location Location of the chunk to get metadata for
 	 * @return ChunkMeta for the requested chunk owned by this plugin, possibly null
@@ -100,6 +116,27 @@ public class ChunkMetaView<T extends ChunkMeta<?>> extends APIView {
 			throw new IllegalArgumentException("Location may not be null");
 		}
 		return getChunkMeta(location.getWorld(), BlockBasedChunkMeta.toChunkCoord(location.getBlockX()), BlockBasedChunkMeta.toChunkCoord(location.getBlockZ()));
+	}
+
+	/**
+	 * Retrieves chunk metadata in the given world for the chunk with the given
+	 * chunk coordinates for this specific plugin.
+	 * If it is not loaded then just return and do not wait
+	 *
+	 * @param world  World the chunk is in
+	 * @param chunkX X-Coordinate of the chunk
+	 * @param chunkZ Z-Coordinate of the chunk
+	 * @return ChunkMetaLoadStatus for the requested chunk owned by this plugin
+	 */
+	@SuppressWarnings("unchecked")
+	public ChunkMetaLoadStatus getChunkMetaIfLoaded(World world, int chunkX, int chunkZ) {
+		if (world == null) {
+			throw new IllegalArgumentException("World may not be null");
+		}
+		if (globalManager == null) {
+			throw new IllegalStateException("View already shut down, can not read data");
+		}
+		return globalManager.getChunkMetaIfLoaded(pluginID, world, chunkX, chunkZ, alwaysLoaded);
 	}
 
 	/**

--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/block/BlockDataObjectLoadStatus.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/block/BlockDataObjectLoadStatus.java
@@ -1,0 +1,13 @@
+package vg.civcraft.mc.civmodcore.world.locations.chunkmeta.block;
+
+import vg.civcraft.mc.civmodcore.world.locations.chunkmeta.ChunkMeta;
+
+public class BlockDataObjectLoadStatus<D extends BlockDataObject> {
+	public final D data;
+	public final boolean isLoaded;
+
+	public BlockDataObjectLoadStatus(D data, boolean isLoaded) {
+		this.data = data;
+		this.isLoaded = isLoaded;
+	}
+}


### PR DESCRIPTION
The method returns immediately after was called without waiting chunk to be loaded.
if isLoaded = true this means that the chunk is loaded and the result contains the actual result.
if isLoaded = false this means that the chunk is not yet loaded.

This change is used by RB to implement a non-blocking randomTick() handler.
The version is increased.