### PR TITLE
Deprecate PlayerMoveBlockEvent

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/events/CustomEventMapper.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/events/CustomEventMapper.java
@@ -1,12 +1,9 @@
 package vg.civcraft.mc.civmodcore.events;
 
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
-import vg.civcraft.mc.civmodcore.world.WorldUtils;
 
 public class CustomEventMapper implements Listener {
 
@@ -14,20 +11,16 @@ public class CustomEventMapper implements Listener {
 	 * Glue map for {@link PlayerMoveBlockEvent}.
 	 * @param event The event to map from.
 	 */
+	@Deprecated
 	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-	public void detectPlayerMoveBlock(PlayerMoveEvent event) {
-		Location formerLocation = event.getFrom();
-		Location latterLocation = event.getTo();
-		// If no block movement has occurred, exit out
-		if (!WorldUtils.doLocationsHaveSameWorld(formerLocation, latterLocation)
-				|| formerLocation.getBlockX() != latterLocation.getBlockX()
-				|| formerLocation.getBlockY() != latterLocation.getBlockY()
-				|| formerLocation.getBlockZ() != latterLocation.getBlockZ()) {
-			return;
+	public void detectPlayerMoveBlock(final PlayerMoveEvent event) {
+		if (event.hasExplicitlyChangedBlock()) {
+			final var better = new PlayerMoveBlockEvent(event.getPlayer(), event.getFrom(), event.getTo());
+			better.callEvent();
+			if (better.isCancelled()) {
+				event.setCancelled(true);
+			}
 		}
-		PlayerMoveBlockEvent better = new PlayerMoveBlockEvent(event.getPlayer(), formerLocation, latterLocation);
-		Bukkit.getPluginManager().callEvent(better);
-		event.setCancelled(better.isCancelled());
 	}
 
 }

--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/events/PlayerMoveBlockEvent.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/events/PlayerMoveBlockEvent.java
@@ -5,6 +5,11 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.PlayerMoveEvent;
 
+/**
+ * @deprecated Please listen to {@link PlayerMoveEvent} instead and check for
+ *             {@link PlayerMoveEvent#hasExplicitlyChangedBlock()}.
+ */
+@Deprecated
 public class PlayerMoveBlockEvent extends PlayerMoveEvent {
 
 	private static final HandlerList handlers = new HandlerList();


### PR DESCRIPTION
`PlayerMoveBlockEvent` was added in [Civclassic #51](https://github.com/CivClassic/CivModCore/pull/51/files#diff-b5e933c7bda869ac14facee5f4afef914d76e85d6adb60d7b8a09d6bdbd8b411=). Its intention was to make listening to *block* movements easier since the `PlayerMoveEvent` event is called even if you make a miniscule movements within a block like looking around, fidgeting, or sneaking, etc.

The resulting solution wasn't ideal since it's an event emitted by another event, so the priority system isn't being used property. I have attempted to fix this somewhat with [CivMC #25](https://github.com/CivMC/CivModCore/pull/25/commits/6c25190c9298409272e1fc8e8dc20766903e8ed0#diff-a053c194bc9510860bda36ad5ca2c578f895a14ca8f08f182b0a6da46f45aa97R55-R69). However, I have since discovered that `PlayerMoveEvent` now has a method named `hasExplicitlyChangedBlock()`, so listening for `PlayerMoveEvent`, checking whether the block has changed, and if so emitting another event is now not only inefficient but entirely unnecessary. In truth, it was never necessary, but it's what Java/OOP brainrot does to you.