### PR TITLE
Fix Aikar commands quirk

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/commands/CommandManager.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/commands/CommandManager.java
@@ -50,9 +50,9 @@ public class CommandManager extends BukkitCommandManager {
 	 * {@link #unregisterCompletions()}, otherwise there may be issues.
 	 */
     public final void init() {
-		registerCommands();
-		registerCompletions(getCommandCompletions());
 		registerContexts(getCommandContexts());
+		registerCompletions(getCommandCompletions());
+		registerCommands();
 	}
 
 	/**

--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/commands/CommandManager.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/commands/CommandManager.java
@@ -73,6 +73,7 @@ public class CommandManager extends BukkitCommandManager {
 		completions.registerAsyncCompletion("allplayers", (context) ->
 				Arrays.stream(Bukkit.getOfflinePlayers())
 						.map(OfflinePlayer::getName)
+						.filter(Objects::nonNull)
 						.toList());
 		completions.registerAsyncCompletion("materials", (context) ->
 				Arrays.stream(Material.values())


### PR DESCRIPTION
There's currently a bug with `CommandManager` that we haven't really encountered because we haven't been using ACF to its fullest potential. For context, ACF command contexts are command-parameter parsers. For an example, consider the following ItemExchange code:
```java
@Subcommand("amount|num|number|a")
@Description("Sets the amount of an exchange rule.")
@Syntax("<amount>")
public void setAmount(Player player, int amount) {
    try (RuleHandler handler = new RuleHandler(player)) {
        if (amount <= 0) {
            throw new InvalidCommandArgument("You must enter a valid amount.");
        }
        handler.getRule().setAmount(amount);
        handler.relay(ChatColor.GREEN + "Amount successfully changed.");
    }
}
```
The `int amount` parameter works because there's a pre-registered context that converts the user-inputted `String` into an `int`, providing automatic errors and responses for when the given value is invalid. Which is great, but when you wish to use a custom context, say NameLayer's `Group` for example and starting using `Group` as the command-parameter instead, the `init` function will throw because ACF is registering the commands first, finding the parameter and having no idea how to handle that type. So this PR puts command registration last and context registration first.