### PR TITLE
Add secondary plugin constructors to support MockBukkit testing

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/ACivMod.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/ACivMod.java
@@ -19,12 +19,24 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.java.JavaPluginLoader;
 import org.jetbrains.annotations.Contract;
 
 public abstract class ACivMod extends JavaPlugin {
 
 	private final Set<Class<? extends ConfigurationSerializable>> configClasses = new HashSet<>(0);
+
+	/** Primary constructor used by the real server */
+	protected ACivMod() {
+		super();
+	}
+
+	/** Secondary constructor used for testing */
+	protected ACivMod(JavaPluginLoader loader, PluginDescriptionFile description, File dataFolder, File file) {
+		super(loader, description, dataFolder, file);
+	}
 
 	@Override
 	public void onEnable() {

--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/CivModCorePlugin.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/CivModCorePlugin.java
@@ -1,9 +1,12 @@
 package vg.civcraft.mc.civmodcore;
 
+import java.io.File;
 import java.sql.SQLException;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.entity.HumanEntity;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.bukkit.plugin.java.JavaPluginLoader;
 import org.ipvp.canvas.MenuFunctionListener;
 import vg.civcraft.mc.civmodcore.chat.dialog.DialogManager;
 import vg.civcraft.mc.civmodcore.commands.CommandManager;
@@ -31,7 +34,17 @@ import vg.civcraft.mc.civmodcore.world.locations.global.CMCWorldDAO;
 import vg.civcraft.mc.civmodcore.world.locations.global.WorldIDManager;
 import vg.civcraft.mc.civmodcore.world.operations.ChunkOperationManager;
 
-public final class CivModCorePlugin extends ACivMod {
+public class CivModCorePlugin extends ACivMod {
+
+	/** Primary constructor used by the real server */
+	public CivModCorePlugin() {
+		super();
+	}
+
+	/** Secondary constructor used for testing */
+	protected CivModCorePlugin(JavaPluginLoader loader, PluginDescriptionFile description, File dataFolder, File file) {
+		super(loader, description, dataFolder, file);
+	}
 
 	private static CivModCorePlugin instance;
 


### PR DESCRIPTION
### Summary

This PR is a non-functional change that adds an additional secondary constructor to the plugin types to support better plugin testability with tools like [MockBukkit](https://github.com/MockBukkit/MockBukkit). The secondary constructor allows the test harness to override the default class-loader and run configurations.

### Testing 


`gradlew locally`