### PR TITLE
Use the proper disablePlugin API

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/ACivMod.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/ACivMod.java
@@ -15,7 +15,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.plugin.Plugin;
@@ -43,10 +42,6 @@ public abstract class ACivMod extends JavaPlugin {
 	
 	@Override
 	public void onDisable() {
-		HandlerList.unregisterAll(this);
-		Bukkit.getMessenger().unregisterIncomingPluginChannel(this);
-		Bukkit.getMessenger().unregisterOutgoingPluginChannel(this);
-		Bukkit.getScheduler().cancelTasks(this);
 		this.configClasses.forEach(ConfigurationSerialization::unregisterClass);
 	}
 
@@ -134,7 +129,7 @@ public abstract class ACivMod extends JavaPlugin {
 	 * Disables this plugin.
 	 */
 	public void disable() {
-		getPluginLoader().disablePlugin(this);
+		getServer().getPluginManager().disablePlugin(this);
 	}
 
 	/**


### PR DESCRIPTION
ACivMod.disable() will now use the correct plugin-disable API, so plugins should correctly disable now. This also means no longer needing all those deregistrations since that's all done automatically by the plugin manager.