### PR TITLE
Add AnvilGUI support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,9 @@ subprojects {
         maven("https://repo.aikar.co/content/groups/aikar/")
         maven("https://libraries.minecraft.net")
 
+		// For AnvilGUI
+		maven("https://repo.codemc.io/repository/maven-snapshots/")
+
 		maven("https://jitpack.io")
 	}
 }

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 	implementation("com.zaxxer:HikariCP:5.0.1")
 	implementation("co.aikar:taskchain-bukkit:3.7.2")
 	implementation("com.github.IPVP-MC:canvas:91ec97f076")
-	compileOnlyApi("net.wesjd:anvilgui:1.9.2-SNAPSHOT")
+	implementation("net.wesjd:anvilgui:1.9.2-SNAPSHOT")
 	implementation("org.apache.commons:commons-lang3:3.12.0")
 	implementation("org.apache.commons:commons-collections4:4.4")
 	implementation("com.google.code.findbugs:jsr305:3.0.2")

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
 	implementation("com.zaxxer:HikariCP:5.0.1")
 	implementation("co.aikar:taskchain-bukkit:3.7.2")
 	implementation("com.github.IPVP-MC:canvas:91ec97f076")
+	compileOnlyApi("net.wesjd:anvilgui:1.9.2-SNAPSHOT")
 	implementation("org.apache.commons:commons-lang3:3.12.0")
 	implementation("org.apache.commons:commons-collections4:4.4")
 	implementation("com.google.code.findbugs:jsr305:3.0.2")

--- a/paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/InventoryUtils.java
+++ b/paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/InventoryUtils.java
@@ -9,11 +9,13 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.experimental.UtilityClass;
+import net.wesjd.anvilgui.AnvilGUI;
 import org.apache.commons.lang3.ArrayUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
 @UtilityClass
@@ -238,4 +240,7 @@ public final class InventoryUtils {
 		return true;
 	}
 
+	public static @NotNull AnvilGUI.Builder newAnvilGui() {
+		return new AnvilGUI.Builder();
+	}
 }

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -10,3 +10,5 @@ permissions:
     default: op
   cmc.debug:
     default: op
+libraries:
+  - "net.wesjd:anvilgui:1.9.2-SNAPSHOT"

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -10,5 +10,3 @@ permissions:
     default: op
   cmc.debug:
     default: op
-libraries:
-  - "net.wesjd:anvilgui:1.9.2-SNAPSHOT"


### PR DESCRIPTION
Follows through on https://github.com/CivClassic/CivModCore/issues/42 and adds [WesJD/AnvilGUI](https://github.com/WesJD/AnvilGUI) support to CivModCore. As with the issue, this is not about replacing or refactoring chat prompts, but rather giving the option to use a more interfacey/Minecrafty way of achieving the same goal. This PR also takes advantage of the [libraries](https://docs.papermc.io/paper/dev/plugin-yml#libraries) config option to avoid making an even fatter CivModCore jar.